### PR TITLE
Add an option to enable or disable Dash/MPD playback

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -51,3 +51,7 @@ msgstr ""
 msgctxt "#30008"
 msgid "Instance settings"
 msgstr ""
+
+msgctxt "#30009"
+msgid "Use Dash/MPD"
+msgstr ""

--- a/resources/lib/invidious_plugin.py
+++ b/resources/lib/invidious_plugin.py
@@ -24,6 +24,7 @@ class InvidiousPlugin:
         self.addon_handle = addon_handle
         self.addon = xbmcaddon.Addon()
         self.args = args
+        self.use_dash = True if xbmcplugin.getSetting(self.addon_handle, "use_dash") == "true" else False
 
         instance_url = xbmcplugin.getSetting(self.addon_handle, "instance_url")
         self.api_client = invidious_api.InvidiousAPIClient(instance_url)
@@ -104,14 +105,15 @@ class InvidiousPlugin:
 
         listitem = None
 
-        # check if playback via MPEG-DASH is possible
-        if "dashUrl" in video_info:
-            is_helper = inputstreamhelper.Helper("mpd")
-            
-            if is_helper.check_inputstream():
-                listitem = xbmcgui.ListItem(path=video_info["dashUrl"])
-                listitem.setProperty("inputstream", is_helper.inputstream_addon)
-                listitem.setProperty("inputstream.adaptive.manifest_type", "mpd")
+        if self.use_dash:
+            # check if playback via MPEG-DASH is possible
+            if "dashUrl" in video_info:
+                is_helper = inputstreamhelper.Helper("mpd")
+                
+                if is_helper.check_inputstream():
+                    listitem = xbmcgui.ListItem(path=video_info["dashUrl"])
+                    listitem.setProperty("inputstream", is_helper.inputstream_addon)
+                    listitem.setProperty("inputstream.adaptive.manifest_type", "mpd")
 
         # as a fallback, we use the first oldschool stream
         if listitem is None:

--- a/resources/lib/invidious_plugin.py
+++ b/resources/lib/invidious_plugin.py
@@ -117,7 +117,7 @@ class InvidiousPlugin:
 
         # as a fallback, we use the first oldschool stream
         if listitem is None:
-            url = video_info["formatStreams"][0]["url"]
+            url = video_info["formatStreams"][-1]["url"]
             # it's pretty complicated to play a video by its URL in Kodi...
             listitem = xbmcgui.ListItem(path=url)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,5 +2,6 @@
 <settings>
     <category id="general" label="30008">
         <setting label="30007" type="text" id="instance_url" default="https://invidious.kavin.rocks"/>
+        <setting label="30009" type="bool" id="use_dash" default="true"/>
     </category>
 </settings>


### PR DESCRIPTION
I've been having some problems with dash where it would play its audio only instead of video, and because I don't know if other people are having this problem, I'm going to just add an option to disable it in case one does.
